### PR TITLE
Added timings to logger to measure request times

### DIFF
--- a/app/request_address.py
+++ b/app/request_address.py
@@ -1,6 +1,10 @@
 import re
 import json
+import time
+
 import requests
+from flask import g
+
 from app import settings
 from structlog import get_logger
 
@@ -28,10 +32,13 @@ def query_address_index(search_value):
 
     logger.info("Request data from address index", url=request_string)
 
+    address_index_request_start = time.time()
     resp = requests.get(request_string,
                         timeout=(settings.REQUEST_CONNECTION_TIMEOUT,
                                  settings.REQUEST_READ_TIMEOUT),
                         headers=headers)
+    g.address_index_response_time = time.time() - address_index_request_start
+    logger.bind(address_index_response_time=g.address_index_response_time)
 
     if resp.status_code != 200:
         # This means something went wrong.

--- a/application.py
+++ b/application.py
@@ -2,7 +2,32 @@
 """
 eq-address-api entry point.
 """
+import logging
+from structlog import configure
+from structlog.processors import JSONRenderer, TimeStamper, format_exc_info
+from structlog.stdlib import add_log_level, LoggerFactory
+from structlog.threadlocal import wrap_dict
+
 from app import app
+
+def configure_logging():
+    # set up some sane logging, as opposed to what flask does by default
+    log_format = "%(message)s"
+    handler = logging.StreamHandler()
+    logging.basicConfig(level=logging.INFO, format=log_format, handlers=[handler])
+
+    def parse_exception(_, __, event_dict):
+        exception = event_dict.get('exception')
+        if exception:
+            event_dict['exception'] = exception.replace("\"", "'").split("\n")
+        return event_dict
+
+    # setup file logging
+    renderer_processor = JSONRenderer()
+    processors = [add_log_level, TimeStamper(key='created', fmt='iso'), format_exc_info, parse_exception, renderer_processor]
+    configure(context_class=wrap_dict(dict), logger_factory=LoggerFactory(), processors=processors, cache_logger_on_first_use=True)
+
+configure_logging()
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Added timings to log message so we can measure latency of Address Index from AWS

```
{"address_index_response_time": 0.2427358627319336, "lookup_api_response_time": 0.25374794006347656, "lookup_api_processing_time": 0.011012077331542969, "event": "Request Complete", "level": "info", "created": "2018-09-21T14:22:46.683808Z"}
```